### PR TITLE
Feature: Add PATCH method to /api/comments/:comment_id endpoint

### DIFF
--- a/controller/comments.controller.js
+++ b/controller/comments.controller.js
@@ -1,6 +1,7 @@
 const {
   selectCommentsByArticleId,
   insertComment,
+  updateCommentVotes,
   removeComment,
 } = require("../model/comments.model");
 
@@ -21,6 +22,16 @@ exports.postComment = async (req, res, next) => {
     res.status(201).send({ comment });
   } catch (err) {
     next(err);
+  }
+};
+
+exports.patchComment = async (req, res, next) => {
+  const { comment_id } = req.params;
+  try {
+    const comment = await updateCommentVotes(comment_id, req.body);
+    res.status(200).send({ comment });
+  } catch (err) {
+    next(err)
   }
 };
 

--- a/endpoints.json
+++ b/endpoints.json
@@ -44,7 +44,7 @@
     }
   },
   "PATCH /api/articles/:article_id": {
-    "description": "update an article",
+    "description": "updates the votes on an article",
     "requestBodyFormat": {
       "inc_votes": 1
     },
@@ -90,6 +90,22 @@
         "article_id": 4,
         "created_at": "2021-03-02T13:00:00.200Z",
         "votes": 0
+      }
+    }
+  },
+  "PATCH /api/comments/:comment_id":{
+    "description": "updates the votes on a comment",
+    "requestBodyFormat": {
+      "inc_votes": 1
+    },
+    "exampleResponse": {
+      "comment": {
+        "comment_id": 47,
+        "body": "example_body",
+        "author": "example_username",
+        "article_id": 4,
+        "created_at": "2021-03-02T13:00:00.200Z",
+        "votes": 1
       }
     }
   },

--- a/model/comments.model.js
+++ b/model/comments.model.js
@@ -48,6 +48,20 @@ exports.insertComment = async (requestBody, article_id) => {
   return rows[0];
 };
 
+exports.updateCommentVotes = async (id, { inc_votes }) => {
+  const { rows } = await db.query(
+    `UPDATE comments
+    SET votes=votes+$1
+    WHERE comment_id=$2
+    RETURNING comment_id, body, author, article_id, created_at, votes`,
+    [inc_votes, id]
+  );
+  if (rows.length === 0) {
+    return Promise.reject({ status: 404, msg: "comment not found" });
+  }
+  return rows[0];
+};
+
 exports.removeComment = async (id) => {
   const { rows } = await db.query(
     "DELETE FROM comments WHERE comment_id=$1 RETURNING *",

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -1,6 +1,9 @@
 const router = require("express").Router();
-const { deleteComment } = require("../controller/comments.controller");
+const {
+  patchComment,
+  deleteComment,
+} = require("../controller/comments.controller");
 
-router.route("/:comment_id").delete(deleteComment);
+router.route("/:comment_id").patch(patchComment).delete(deleteComment);
 
 module.exports = router;


### PR DESCRIPTION
Sending a PATCH request to this endpoint can be used to change the votes on a comment Includes error handling for invalid comment_id and invalid request body