### PR TITLE
Feature: Add pagination to GET /api/articles/:article_id/comments endpoint

### DIFF
--- a/controller/comments.controller.js
+++ b/controller/comments.controller.js
@@ -8,7 +8,7 @@ const {
 exports.getCommentsByArticleId = async (req, res, next) => {
   const { article_id } = req.params;
   try {
-    const comments = await selectCommentsByArticleId(article_id);
+    const comments = await selectCommentsByArticleId(article_id, req.query);
     res.status(200).send({ comments });
   } catch (err) {
     next(err);

--- a/endpoints.json
+++ b/endpoints.json
@@ -101,6 +101,7 @@
   },
   "GET /api/articles/:article_id/comments": {
     "description": "serves an array of all comments on an article",
+    "queries": ["limit", "p"],
     "exampleResponse": {
       "comments": [
         {


### PR DESCRIPTION
Can now use p and limit query parameters to paginate the results from this endpoint
Error handling covers invalid query args and not returning any comments because p too high