### PR TITLE
Fix: total_count now correctly counts all articles filtered for, not just those on current page

### DIFF
--- a/controller/articles.controller.js
+++ b/controller/articles.controller.js
@@ -7,8 +7,8 @@ const {
 
 exports.getArticles = async (req, res, next) => {
   try {
-    const articles = await selectArticles(req.query);
-    res.status(200).send({ articles, total_count: articles.length });
+    const { articles, total_count } = await selectArticles(req.query);
+    res.status(200).send({ articles, total_count });
   } catch (err) {
     next(err);
   }

--- a/endpoints.json
+++ b/endpoints.json
@@ -24,22 +24,8 @@
           "article_img_url": "https://example.com/photos/1323/example.jpeg",
           "comment_count": 13
         }
-      ]
-    },
-    "examplePaginatedResponse": {
-      "articles": [
-        {
-          "article_id": 7,
-          "title": "Seafood substitutions are increasing",
-          "topic": "cooking",
-          "author": "weegembump",
-          "created_at": "2018-05-30T15:59:13.341Z",
-          "votes": 0,
-          "article_img_url": "https://example.com/photos/1323/example.jpeg",
-          "comment_count": 13
-        }
       ],
-      "total_count": 1
+      "total_count": 13
     }
   },
   "POST /api/articles": {

--- a/model/articles.model.js
+++ b/model/articles.model.js
@@ -47,9 +47,9 @@ exports.selectArticles = async (queryParams) => {
     }
   }
 
-  const { rows } = await db.query(queryStr, queryValues);
+  const { rows: articles } = await db.query(queryStr, queryValues);
 
-  if (rows.length === 0) {
+  if (articles.length === 0) {
     if (!topic) {
       return Promise.reject({ status: 404, msg: "page not found" });
     }
@@ -59,7 +59,19 @@ exports.selectArticles = async (queryParams) => {
     }
   }
 
-  return rows;
+  let totalArticlesQueryStr =
+    "SELECT COUNT(*)::INT AS total_count FROM articles";
+  const totalArticlesQueryValues = [];
+  if (topic) {
+    totalArticlesQueryStr += " WHERE topic=$1";
+    totalArticlesQueryValues.push(topic);
+  }
+
+  const {
+    rows: [{ total_count }],
+  } = await db.query(totalArticlesQueryStr, totalArticlesQueryValues);
+
+  return { articles, total_count };
 };
 
 exports.insertArticle = async ({


### PR DESCRIPTION
The response to a GET request to /api/articles has the property total_count which is the total number of articles, with the topic filter applied. This previously was only counting articles by page when the request included pagination. This pull request changes the behaviour to what is desired.