### PR TITLE
Feature: Add POST method to /api/topics endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -38,18 +38,68 @@ describe("/api", () => {
 });
 
 describe("/api/topics", () => {
-  test("GET 200: reponds with all topics", () => {
-    return request(app)
-      .get("/api/topics/")
-      .expect(200)
-      .then(({ body }) => {
-        const { topics } = body;
-        expect(topics.length).toBe(3);
-        topics.forEach((topic) => {
-          expect(typeof topic.slug).toBe("string");
-          expect(typeof topic.description).toBe("string");
+  describe("GET", () => {
+    test("200: responds with all topics", () => {
+      return request(app)
+        .get("/api/topics/")
+        .expect(200)
+        .then(({ body }) => {
+          const { topics } = body;
+          expect(topics.length).toBe(3);
+          topics.forEach((topic) => {
+            expect(typeof topic.slug).toBe("string");
+            expect(typeof topic.description).toBe("string");
+          });
         });
-      });
+    });
+  });
+
+  describe("POST", () => {
+    test("201: responds with newly created topic", () => {
+      const testBody = {
+        slug: "test topic",
+        description: "test topic description",
+      };
+      const expected = {
+        slug: "test topic",
+        description: "test topic description",
+      };
+      return request(app)
+        .post("/api/topics")
+        .send(testBody)
+        .expect(201)
+        .then(({ body: { topic } }) => {
+          expect(topic).toMatchObject(expected);
+        });
+    });
+
+    test("201: request body doesn't need a description", () => {
+      const testBody = {
+        slug: "test topic",
+      };
+      const expected = {
+        slug: "test topic",
+        description: null,
+      };
+      return request(app)
+        .post("/api/topics")
+        .send(testBody)
+        .expect(201)
+        .then(({ body: { topic } }) => {
+          expect(topic).toMatchObject(expected);
+        });
+    });
+
+    test("400: when slug is missing from request body", () => {
+      const testBody = { description: "test topic description" };
+      return request(app)
+        .post("/api/topics")
+        .send(testBody)
+        .expect(400)
+        .then(({ body: { msg } }) => {
+          expect(msg).toBe("bad request");
+        });
+    });
   });
 });
 

--- a/controller/topics.controller.js
+++ b/controller/topics.controller.js
@@ -1,6 +1,15 @@
-const { selectTopics } = require("../model/topics.model.js")
+const { selectTopics, insertTopic } = require("../model/topics.model.js");
 
 exports.getTopics = async (req, res, next) => {
-  const topics = await selectTopics()
-  res.status(200).send({ topics })
+  const topics = await selectTopics();
+  res.status(200).send({ topics });
+};
+
+exports.postTopic = async (req, res, next) => {
+  try {
+    const topic = await insertTopic(req.body);
+    res.status(201).send({ topic });
+  } catch (err) {
+    next(err);
+  }
 };

--- a/endpoints.json
+++ b/endpoints.json
@@ -9,6 +9,19 @@
       "topics": [{ "slug": "football", "description": "Footie!" }]
     }
   },
+  "POST /api/topics": {
+    "description": "adds a new topic",
+    "requestBodyFormat": {
+      "slug": "topic name here",
+      "description": "description here"
+    },
+    "exampleResponse": {
+      "topic": {
+        "slug": "topic name here",
+        "description": "description here"
+      }
+    }
+  },
   "GET /api/articles": {
     "description": "serves an array of all articles, by default sorted by date in descending order",
     "queries": ["topic", "sort_by", "order", "limit", "p"],

--- a/model/topics.model.js
+++ b/model/topics.model.js
@@ -1,6 +1,19 @@
 const db = require("../db/connection");
 
 exports.selectTopics = async () => {
-  const { rows } = await db.query("SELECT slug, description FROM topics")
-  return rows
+  const { rows } = await db.query("SELECT slug, description FROM topics");
+  return rows;
+};
+
+exports.insertTopic = async ({ slug, description }) => {
+  const { rows } = await db.query(
+    `INSERT INTO topics
+    (slug, description)
+    VALUES
+    ($1, $2)
+    RETURNING *`,
+    [slug, description]
+  );
+
+  return rows[0];
 };

--- a/routes/topics.js
+++ b/routes/topics.js
@@ -1,6 +1,6 @@
 const router = require("express").Router();
-const { getTopics } = require("../controller/topics.controller");
+const { getTopics, postTopic } = require("../controller/topics.controller");
 
-router.route("/").get(getTopics);
+router.route("/").get(getTopics).post(postTopic);
 
 module.exports = router;


### PR DESCRIPTION
Can now POST a new topic using this endpoint
New topics require a slug, but don't require a description
If no slug given, responds with 400 bad request error