### PR TITLE
Feature: Add DELETE method to /api/articles/:article_id endpoint

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -623,6 +623,30 @@ describe("/api/articles/:article_id", () => {
         });
     });
   });
+
+  describe("DELETE", () => {
+    test("204: on successful delete of article and it's comments", () => {
+      return request(app).delete("/api/articles/1").expect(204);
+    });
+
+    test("400: when given article_id is invalid", () => {
+      return request(app)
+        .delete("/api/articles/invalid_article")
+        .expect(400)
+        .then(({ body: { msg } }) => {
+          expect(msg).toBe("bad request");
+        });
+    });
+
+    test("404: when given article_id is valid but article doesn't exist", () => {
+      return request(app)
+        .delete("/api/articles/1000038")
+        .expect(404)
+        .then(({ body: { msg } }) => {
+          expect(msg).toBe("article not found");
+        });
+    });
+  });
 });
 
 describe("/api/articles/:article_id/comments", () => {

--- a/controller/articles.controller.js
+++ b/controller/articles.controller.js
@@ -3,6 +3,7 @@ const {
   insertArticle,
   selectArticleById,
   updateArticleVotes,
+  removeArticle,
 } = require("../model/articles.model.js");
 
 exports.getArticles = async (req, res, next) => {
@@ -39,6 +40,16 @@ exports.patchArticle = async (req, res, next) => {
   try {
     const article = await updateArticleVotes(article_id, req.body);
     res.status(200).send({ article });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.deleteArticle = async (req, res, next) => {
+  const { article_id } = req.params;
+  try {
+    await removeArticle(article_id);
+    res.status(204).send();
   } catch (err) {
     next(err);
   }

--- a/endpoints.json
+++ b/endpoints.json
@@ -98,6 +98,9 @@
       }
     }
   },
+  "DELETE /api/articles/:article_id": {
+    "description": "deletes an article and all it's comments"
+  },
   "GET /api/articles/:article_id/comments": {
     "description": "serves an array of all comments on an article",
     "queries": ["limit", "p"],

--- a/model/articles.model.js
+++ b/model/articles.model.js
@@ -145,3 +145,20 @@ exports.updateArticleVotes = async (id, { inc_votes }) => {
   }
   return rows[0];
 };
+
+exports.removeArticle = async (id) => {
+  await db.query(
+    `DELETE FROM comments
+    WHERE article_id=$1`,
+    [id]
+  );
+  const { rows } = await db.query(
+    `DELETE FROM articles
+    WHERE article_id=$1
+    RETURNING *`,
+    [id]
+  );
+  if (rows.length === 0) {
+    return Promise.reject({status:404, msg:"article not found"})
+  }
+};

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -4,6 +4,7 @@ const {
   postArticle,
   getArticleById,
   patchArticle,
+  deleteArticle,
 } = require("../controller/articles.controller");
 const {
   getCommentsByArticleId,
@@ -12,7 +13,11 @@ const {
 
 router.route("/").get(getArticles).post(postArticle);
 
-router.route("/:article_id").get(getArticleById).patch(patchArticle);
+router
+  .route("/:article_id")
+  .get(getArticleById)
+  .patch(patchArticle)
+  .delete(deleteArticle);
 
 router
   .route("/:article_id/comments")


### PR DESCRIPTION
Can use this endpoint to delete an article and all it's comments.
Returns 400 when article_id is invalid and 404 when article_id is valid but article doesn't exist.