### PR TITLE
Refactor: Add handleSimple404 util function

### DIFF
--- a/model/users.model.js
+++ b/model/users.model.js
@@ -1,4 +1,5 @@
 const db = require("../db/connection");
+const { handleSimple404 } = require("./utils.model");
 
 exports.selectUsers = async () => {
   const { rows } = await db.query(
@@ -7,14 +8,16 @@ exports.selectUsers = async () => {
   return rows;
 };
 
-exports.selectUserByUsername = async (username) => {
+const naiveSelectUserByUsername = async (username) => {
   const { rows } = await db.query(
     `SELECT username, name, avatar_url FROM users
     WHERE username=$1`,
     [username]
   );
-  if (rows.length === 0) {
-    return Promise.reject({ status: 404, msg: "username not found" });
-  }
   return rows[0];
 };
+
+exports.selectUserByUsername = handleSimple404(
+  naiveSelectUserByUsername,
+  "username not found"
+);

--- a/model/utils.model.js
+++ b/model/utils.model.js
@@ -6,3 +6,14 @@ exports.checkExists = async (table, column, value) => {
   ]);
   return rows.length !== 0;
 };
+
+exports.handleSimple404 = (modelFunc, errorMsg) => {
+  const wrappedModelFunc = async (...args) => {
+    const result = await modelFunc(...args);
+    if (!result || (Array.isArray(result) && result.length === 0)) {
+      return Promise.reject({ status: 404, msg: errorMsg });
+    }
+    return result;
+  };
+  return wrappedModelFunc;
+};


### PR DESCRIPTION
Before this change there was a lot of repetition in model functions where they would raise a 404 error if their database query didn't find anything. To eliminate repetition, I wrote a handleSimple404 wrapper function with a full set of unit tests which wraps one of these model functions and returns a function with 404 handling functionailty.