### PR TITLE
Feature: Add 405 error handling

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -1049,3 +1049,23 @@ describe("/api/users/:username", () => {
     });
   });
 });
+
+describe("405 method not allowed errors", () => {
+  test("sending unsupported method to an endpoint results in a 405 response", () => {
+    return request(app).delete("/api/articles").expect(405);
+  });
+
+  test("response header has allow field with allowed responses", () => {
+    const test1 = request(app)
+      .delete("/api/articles")
+      .expect(405)
+      .expect("Allow", "GET, POST");
+
+    const test2 = request(app)
+      .patch("/api/users")
+      .expect(405)
+      .expect("Allow", "GET");
+
+    return Promise.all([test1, test2]);
+  });
+});

--- a/routes/articles.js
+++ b/routes/articles.js
@@ -10,18 +10,31 @@ const {
   getCommentsByArticleId,
   postComment,
 } = require("../controller/comments.controller");
+const { send405Response } = require("./middleware");
 
-router.route("/").get(getArticles).post(postArticle);
+router
+  .route("/")
+  .get(getArticles)
+  .post(postArticle)
+  .all((req, res, next) => {
+    send405Response(res, ["GET", "POST"]);
+  });
 
 router
   .route("/:article_id")
   .get(getArticleById)
   .patch(patchArticle)
-  .delete(deleteArticle);
+  .delete(deleteArticle)
+  .all((req, res, next) => {
+    send405response(res, ["GET", "PATCH", "DELETE"]);
+  });
 
 router
   .route("/:article_id/comments")
   .get(getCommentsByArticleId)
-  .post(postComment);
+  .post(postComment)
+  .all((req, res, next) => {
+    send405response(res, ["GET", "POST"]);
+  });
 
 module.exports = router;

--- a/routes/comments.js
+++ b/routes/comments.js
@@ -3,7 +3,14 @@ const {
   patchComment,
   deleteComment,
 } = require("../controller/comments.controller");
+const { send405Response } = require("./middleware");
 
-router.route("/:comment_id").patch(patchComment).delete(deleteComment);
+router
+  .route("/:comment_id")
+  .patch(patchComment)
+  .delete(deleteComment)
+  .all((req, res, next) => {
+    send405Response(res, ["PATCH", "DELETE"]);
+  });
 
 module.exports = router;

--- a/routes/middleware.js
+++ b/routes/middleware.js
@@ -1,0 +1,4 @@
+exports.send405Response = (res, allowed) => {
+  res.set("Allow", allowed.join(", "));
+  res.status(405).send();
+};

--- a/routes/topics.js
+++ b/routes/topics.js
@@ -1,6 +1,13 @@
 const router = require("express").Router();
 const { getTopics, postTopic } = require("../controller/topics.controller");
+const { send405Response } = require("./middleware");
 
-router.route("/").get(getTopics).post(postTopic);
+router
+  .route("/")
+  .get(getTopics)
+  .post(postTopic)
+  .all((req, res, next) => {
+    send405Response(res, ["GET", "POST"]);
+  });
 
 module.exports = router;

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,8 +1,22 @@
 const router = require("express").Router();
-const { getUsers, getUserByUsername } = require("../controller/users.controller");
+const {
+  getUsers,
+  getUserByUsername,
+} = require("../controller/users.controller");
+const { send405Response } = require("./middleware");
 
-router.route("/").get(getUsers);
+router
+  .route("/")
+  .get(getUsers)
+  .all((req, res, next) => {
+    send405Response(res, ["GET"]);
+  });
 
-router.route("/:username").get(getUserByUsername)
+router
+  .route("/:username")
+  .get(getUserByUsername)
+  .all((req, res, next) => {
+    send405response(res, ["GET"]);
+  });
 
 module.exports = router;


### PR DESCRIPTION
Previously, sending requests to endpoints with unallowed methods resulted in a 404 error. I have changed this so that the response is a more appropriate 405 error.